### PR TITLE
+fixs syntax issue on Terraform v0.12.2 #2

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -32,7 +32,7 @@ resource "aws_iam_role" "scheduled_task_cloudwatch" {
 data "template_file" "scheduled_task_cloudwatch_policy" {
   template = "${file("${path.module}/policies/scheduled-task-cloudwatch-policy.json")}"
 
-  vars {
+  vars =  {
     task_execution_role_arn = "${aws_iam_role.scheduled_task_ecs_execution.arn}"
   }
 }


### PR DESCRIPTION
I get a strange syntax error on my localmachine, the module works fine after adding `=`

error;
```
Error: Unsupported block type

  on ../../modules/terraform-aws-ecs-scheduled-task/main.tf line 35, in data "template_file" "scheduled_task_cloudwatch_policy":
  35:   vars {

Blocks of type "vars" are not expected here. Did you mean to define argument
"vars"? If so, use the equals sign to assign it a value.
```

tf version;
```
$ terraform --version
Terraform v0.12.2
```