### PR TITLE
Fix "source" syntax in main usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Terraform module to create a scheduled task in AWS ECS
 
 ``` hcl
 module "scheduled_task" {
-  source  = "github.com:dxw/terraform-aws-ecs-scheduled-task"
+  source  = "github.com/dxw/terraform-aws-ecs-scheduled-task"
   version = "1.2"
 
   name                  = "my_awesome_task"


### PR DESCRIPTION
According to https://www.terraform.io/docs/modules/sources.html#github there should be a slash after "github.com".