### PR TITLE
Add jsonencode func so that not to invoke unexpected resource update

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -69,6 +69,7 @@ resource "aws_cloudwatch_event_target" "scheduled_task" {
   rule      = "${aws_cloudwatch_event_rule.scheduled_task.name}"
   arn       = "${var.cluster_arn}"
   role_arn  = "${aws_iam_role.scheduled_task_cloudwatch.arn}"
+  input     = jsonencode({})
 
   ecs_target {
     task_count          = "${var.task_count}"


### PR DESCRIPTION
WIthout designating "input" parameter on aws_cloudwatch_event_target, next 'terraform plan' says it'll update the resource even if no changes in HCL. plan output might be below.

![スクリーンショット 2020-02-05 16 19 35](https://user-images.githubusercontent.com/6092300/73819641-53855380-4833-11ea-9f48-43f2b1489552.png)

"input" with empty json can be used to avoid this case.